### PR TITLE
Truncate long space names with ellipsis

### DIFF
--- a/explorer/src/routes/+page.svelte
+++ b/explorer/src/routes/+page.svelte
@@ -47,7 +47,7 @@
             class="group hover:z-10 relative group flex flex-col py-7 gap-2 rounded-3xl border border-b-8 border-primary w-[220px] cursor-pointer text-primary hover:bg-primary hover:text-primary-content hover:sc1ale-110 bg-base-100 transition-transform duration-300"
           >
             <div class="px-4 flex flex-col gap-2">
-              <span class="text-lg light:text-primary-content text-gray-400 font-semibold tracking-wider truncate">{space.name}</span>
+              <span title={space.name} class="text-lg light:text-primary-content text-gray-400 font-semibold tracking-wider truncate">{space.name}</span>
               {#if space.claimHeight > currentBlockHeight}
                 <div class="flex gap-2 items-center text-gray-600 group-hover:text-primary-content text-sm">
                   Ends in:

--- a/explorer/src/routes/+page.svelte
+++ b/explorer/src/routes/+page.svelte
@@ -47,7 +47,7 @@
             class="group hover:z-10 relative group flex flex-col py-7 gap-2 rounded-3xl border border-b-8 border-primary w-[220px] cursor-pointer text-primary hover:bg-primary hover:text-primary-content hover:sc1ale-110 bg-base-100 transition-transform duration-300"
           >
             <div class="px-4 flex flex-col gap-2">
-              <span class="text-lg light:text-primary-content text-gray-400 font-semibold tracking-wider">{space.name}</span>
+              <span class="text-lg light:text-primary-content text-gray-400 font-semibold tracking-wider truncate">{space.name}</span>
               {#if space.claimHeight > currentBlockHeight}
                 <div class="flex gap-2 items-center text-gray-600 group-hover:text-primary-content text-sm">
                   Ends in:

--- a/indexer/src/index.ts
+++ b/indexer/src/index.ts
@@ -222,7 +222,7 @@ async function sync() {
         startTime = performance.now();
 
         const last_sync = (await db.select().from(syncs).orderBy(desc(syncs.endBlockHeight)).limit(1))?.[0];
-        let height = last_sync?.endBlockHeight ? (last_sync.endBlockHeight + 1) : process.env.SPACES_STARTING_BLOCKHEIGHT;
+        let height = last_sync?.endBlockHeight ? (last_sync.endBlockHeight + 1) : Number(process.env.SPACES_STARTING_BLOCKHEIGHT);
         startBlockHeight = height;
 
         const bitcoinClient = new SimpleRpcClient(process.env.BITCOIN_RPC_URL, process.env.BITCOIN_RPC_USER, process.env.BITCOIN_RPC_PASSWORD);


### PR DESCRIPTION
In this PR, we truncate long space names and show a basic, accessible HTML tooltip on popover.

Before:
<img width="258" alt="image" src="https://github.com/user-attachments/assets/fecee3dd-186e-48ee-a18a-cae778e3b601">

After:
<img width="338" alt="image" src="https://github.com/user-attachments/assets/92a84b4b-9f47-4cdc-8f78-3ecea1c63da1">
