### PR TITLE
Update documentation to use testnet4

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ To run it via Docker run the following command from the root directory, i.e. the
 docker compose up -d
 ```
 
-Create the database schema: 
+Create the database schema:
 
 ```bash
 cd indexer

--- a/README.md
+++ b/README.md
@@ -148,21 +148,33 @@ If needed, make changes to the `.env` file but if you fully followed this guide 
 
 ### Run the explorer
 
-Run the Explorer using `pm2`:
+You can start the explorer directly in the terminal or make it run in the background using `pm2` and have it running even when you exit the terminal.
+
+To start it in the terminal run:
+
+```bash
+npm run dev
+```
+
+Then you can open the browser at: `http://localhost:5173/`
+
+To run it via `pm2` make sure to first install `pm2`:
+
+```bash
+npm i -g pm2
+```
+
+Then build the app and run it:
 
 ```bash
 npm run build
 pm2 start build/server.js
 ```
 
-Check if it is running:
+Make sure it's running:
 
 ```bash
 pm2 status
 ```
 
-Open the explorer in a browser:
-
-```
-http://localhost:3000
-```
+You can then open the explorer in a browser: `http://localhost:3000`

--- a/explorer/.env.example
+++ b/explorer/.env.example
@@ -1,2 +1,2 @@
 DB_URL=postgres://postgres:password@localhost:5432/spacesprotocol_explorer
-PUBLIC_BTC_NETWORK=test
+PUBLIC_BTC_NETWORK=testnet4

--- a/indexer/.env.example
+++ b/indexer/.env.example
@@ -5,4 +5,3 @@ BITCOIN_RPC_URL=http://localhost:48332
 BITCOIN_RPC_USER=testnet4
 BITCOIN_RPC_PASSWORD=testnet4
 SPACED_RPC_URL=http://localhost:7224
-

--- a/indexer/.env.example
+++ b/indexer/.env.example
@@ -1,7 +1,8 @@
 DB_URL=postgres://postgres:password@localhost:5432/spacesprotocol_explorer
 NETWORK=testnet4
-SPACES_STARTING_BLOCKHEIGHT=0
-BITCOIN_RPC_URL=http://localhost:18332
-BITCOIN_RPC_USER=test
-BITCOIN_RPC_PASSWORD=test
-SPACED_RPC_URL=http://localhost:22221
+SPACES_STARTING_BLOCKHEIGHT=38580
+BITCOIN_RPC_URL=http://localhost:48332
+BITCOIN_RPC_USER=testnet4
+BITCOIN_RPC_PASSWORD=testnet4
+SPACED_RPC_URL=http://localhost:7224
+


### PR DESCRIPTION
In this PR we update our documentation to reflect that spaces in now on `testnet4`. In addition, we make the documentation for the `indexer` and `explorer` consistent to show that both can be run in the terminal or via `pm2` as a background process.